### PR TITLE
relaxed file extensions

### DIFF
--- a/docs/dist/idocs.host.umd.js
+++ b/docs/dist/idocs.host.umd.js
@@ -4211,7 +4211,7 @@ ${content}
     targetMarkdown
   }, Symbol.toStringTag, { value: "Module" }));
   function readFile(file, host) {
-    if (file.name.endsWith(".idoc.json") || file.name.endsWith(".idoc.md")) {
+    if (file.name.endsWith(".json") || file.name.endsWith(".md")) {
       const reader = new FileReader();
       reader.onload = (e) => {
         var _a;
@@ -4231,7 +4231,7 @@ ${content}
           );
           return;
         }
-        if (file.name.endsWith(".idoc.json")) {
+        if (file.name.endsWith(".json")) {
           try {
             const idoc = JSON.parse(content);
             host.render(void 0, idoc);
@@ -4243,7 +4243,7 @@ ${content}
             );
             return;
           }
-        } else if (file.name.endsWith(".idoc.md")) {
+        } else if (file.name.endsWith(".md")) {
           host.render(content);
         }
       };
@@ -4254,7 +4254,7 @@ ${content}
     } else {
       host.errorHandler(
         new Error("Invalid file type"),
-        "Only markdown (.idoc.md) or JSON (.idoc.json) files are supported."
+        "Only markdown (.md) or JSON (.json) files are supported."
       );
     }
   }

--- a/packages/host/src/file.ts
+++ b/packages/host/src/file.ts
@@ -1,7 +1,7 @@
 import { Listener } from "./listener.js";
 
 export function readFile(file: File, host: Listener) {
-    if (file.name.endsWith('.idoc.json') || file.name.endsWith('.idoc.md')) {
+    if (file.name.endsWith('.json') || file.name.endsWith('.md')) {
         const reader = new FileReader();
         reader.onload = (e) => {
             let content = e.target?.result as string;
@@ -20,7 +20,7 @@ export function readFile(file: File, host: Listener) {
                 );
                 return;
             }
-            if (file.name.endsWith('.idoc.json')) {
+            if (file.name.endsWith('.json')) {
                 try {
                     const idoc = JSON.parse(content);
                     host.render(undefined, idoc);
@@ -32,7 +32,7 @@ export function readFile(file: File, host: Listener) {
                     );
                     return;
                 }
-            } else if (file.name.endsWith('.idoc.md')) {
+            } else if (file.name.endsWith('.md')) {
                 host.render(content);
             }
         };
@@ -43,7 +43,7 @@ export function readFile(file: File, host: Listener) {
     } else {
         host.errorHandler(
             new Error('Invalid file type'),
-            'Only markdown (.idoc.md) or JSON (.idoc.json) files are supported.'
+            'Only markdown (.md) or JSON (.json) files are supported.'
         );
     }
 }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -65,81 +65,81 @@
         },
         {
           "command": "interactive-documents-vscode.previewIdoc",
-          "when": "resourceExtname == .md && resourceFilename =~ /\\.idoc\\.md$/",
+          "when": "resourceExtname == .md && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.md$/",
           "group": "interactive-documents"
         },
         {
           "command": "interactive-documents-vscode.previewIdoc",
-          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc\\.json$/",
+          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.json$/",
           "group": "interactive-documents"
         },
         {
           "command": "interactive-documents-vscode.convertToHtml",
-          "when": "resourceExtname == .md && resourceFilename =~ /\\.idoc\\.md$/",
+          "when": "resourceExtname == .md && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.md$/",
           "group": "interactive-documents"
         },
         {
           "command": "interactive-documents-vscode.convertToHtml",
-          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc\\.json$/",
+          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.json$/",
           "group": "interactive-documents"
         },
         {
           "command": "interactive-documents-vscode.convertToMarkdown",
-          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc\\.json$/",
+          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.json$/",
           "group": "interactive-documents"
         },
         {
           "command": "interactive-documents-vscode.editIdoc",
-          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc\\.json$/",
+          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.json$/",
           "group": "interactive-documents"
         }
       ],
       "editor/title": [
         {
           "command": "interactive-documents-vscode.previewIdocSplit",
-          "when": "resourceExtname == .md && resourceFilename =~ /\\.idoc\\.md$/",
+          "when": "resourceExtname == .md && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.md$/",
           "group": "navigation"
         },
         {
           "command": "interactive-documents-vscode.previewIdocSplit",
-          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc\\.json$/",
+          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.json$/",
           "group": "navigation"
         }
       ],
       "editor/title/context": [
         {
           "command": "interactive-documents-vscode.previewIdoc",
-          "when": "resourceExtname == .md && resourceFilename =~ /\\.idoc\\.md$/",
+          "when": "resourceExtname == .md && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.md$/",
           "group": "interactive-documents"
         },
         {
           "command": "interactive-documents-vscode.previewIdoc",
-          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc\\.json$/",
+          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.json$/",
           "group": "interactive-documents"
         },
         {
           "command": "interactive-documents-vscode.convertToHtml",
-          "when": "resourceExtname == .md && resourceFilename =~ /\\.idoc\\.md$/",
+          "when": "resourceExtname == .md && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.md$/",
           "group": "interactive-documents"
         },
         {
           "command": "interactive-documents-vscode.convertToHtml",
-          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc\\.json$/",
+          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.json$/",
           "group": "interactive-documents"
         },
         {
           "command": "interactive-documents-vscode.convertToMarkdown",
-          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc\\.json$/",
+          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.json$/",
           "group": "interactive-documents"
         },
         {
           "command": "interactive-documents-vscode.editIdoc",
-          "when": "resourceExtname == .md && resourceFilename =~ /\\.idoc\\.md$/",
+          "when": "resourceExtname == .md && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.md$/",
           "group": "interactive-documents"
         },
         {
           "command": "interactive-documents-vscode.editIdoc",
-          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc\\.json$/",
+          "when": "resourceExtname == .json && resourceFilename =~ /\\.idoc( copy( \\d+)?)?\\.json$/",
           "group": "interactive-documents"
         }
       ]

--- a/packages/vscode/src/web/command-convert-html.ts
+++ b/packages/vscode/src/web/command-convert-html.ts
@@ -17,11 +17,11 @@ export async function convertToHtml(fileUri: vscode.Uri) {
 		let htmlContent: string;
 		let originalExtension: string;
 
-		if (fileName.endsWith('.idoc.json')) {
+		if (fileName.endsWith('.json')) {
 			// Handle JSON files
 			htmlContent = htmlJsonWrapper(fileText, fileUri);
 			originalExtension = '.idoc.json';
-		} else if (fileName.endsWith('.idoc.md')) {
+		} else if (fileName.endsWith('.md')) {
 			// Handle Markdown files
 			htmlContent = htmlMarkdownWrapper(fileText, fileUri);
 			originalExtension = '.idoc.md';

--- a/packages/vscode/src/web/command-edit.ts
+++ b/packages/vscode/src/web/command-edit.ts
@@ -112,7 +112,7 @@ export class EditManager {
 				//TODO: we need to decompile??
 
 				//this.render({ markdown });
-			} else if (uriFsPath.endsWith('.idoc.json')) {
+			} else if (uriFsPath.endsWith('.json')) {
 				// If the file is a JSON file, we can send the JSON content
 				const jsonContent = new TextDecoder().decode(uint8array);
 				try {

--- a/packages/vscode/src/web/command-preview.ts
+++ b/packages/vscode/src/web/command-preview.ts
@@ -82,10 +82,10 @@ export class PreviewManager {
 		vscode.workspace.fs.readFile(fileUri).then(uint8array => {
 
 			// If the file is a markdown file, we can send the markdown content
-			if (uriFsPath.endsWith('.idoc.md')) {
+			if (uriFsPath.endsWith('.md')) {
 				const markdown = new TextDecoder().decode(uint8array);
 				this.render({ markdown });
-			} else if (uriFsPath.endsWith('.idoc.json')) {
+			} else if (uriFsPath.endsWith('.json')) {
 				// If the file is a JSON file, we can send the JSON content
 				const jsonContent = new TextDecoder().decode(uint8array);
 				try {


### PR DESCRIPTION
Accept OS-renamed copies, e.g. `foo.idoc.json` becomes `foo.idoc copy.json`, `foo.idoc copy 2.json` etc. 