### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/chartifact/security/code-scanning/25](https://github.com/microsoft/chartifact/security/code-scanning/25)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow primarily interacts with repository contents (e.g., checking out code), the `contents: read` permission is sufficient. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

The `permissions` block should be added at the root level of the workflow file, applying to all jobs in the workflow. No additional dependencies or changes to the workflow steps are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
