### PR TITLE
Fitness Rings Example

### DIFF
--- a/docs/assets/examples/examples.json.folder.json
+++ b/docs/assets/examples/examples.json.folder.json
@@ -52,6 +52,11 @@
       "title": "Personal Bank Statement",
       "description": "Track your transactions and spending patterns.",
       "href": "json/bank-statement.idoc.json"
+    },
+    {
+      "title": "Fitness Rings",
+      "description": "Interactive fitness tracker with activity rings visualization.",
+      "href": "json/activity-rings.idoc.json"
     }
   ]
 }

--- a/docs/assets/examples/examples.markdown.folder.json
+++ b/docs/assets/examples/examples.markdown.folder.json
@@ -51,6 +51,11 @@
       "title": "Personal Bank Statement",
       "description": "Track your transactions and spending patterns.",
       "href": "markdown/bank-statement.idoc.md"
+    },
+    {
+      "title": "Fitness Rings",
+      "description": "Interactive fitness tracker with activity rings visualization.",
+      "href": "markdown/activity-rings.idoc.md"
     }
   ]
 }

--- a/packages/web-deploy/json/activity-rings.idoc.json
+++ b/packages/web-deploy/json/activity-rings.idoc.json
@@ -4,11 +4,12 @@
     "style": {
         "css": [
             "body { font-family: 'SF Pro Display', 'Helvetica Neue', 'Arial', sans-serif; margin: 0; padding: 20px; background: #000; color: #fff; }",
-            "body { display: grid; grid-template-areas: 'header' 'controls' 'rings' 'bars'; grid-template-columns: 1fr; gap: 30px; max-width: 800px; margin: 0 auto; }",
+            "body { display: grid; grid-template-areas: 'header' 'controls' 'rings' 'table' 'bars'; grid-template-columns: 1fr; gap: 30px; max-width: 800px; margin: 0 auto; }",
             ".group { background: #1c1c1e; padding: 25px; border-radius: 20px; border: 1px solid #38383a; }",
             "#header { grid-area: header; text-align: center; background: none; border: none; padding: 0; }",
             "#controls { grid-area: controls; }",
             "#rings { grid-area: rings; min-width: 0; display: flex; justify-content: center; align-items: center; }",
+            "#table { grid-area: table; min-width: 0; overflow: hidden; }",
             "#bars { grid-area: bars; min-width: 0; display: grid; grid-template-columns: 1fr; gap: 20px; }",
             "h1 { margin: 0 0 30px 0; font-size: 2.5em; font-weight: 700; }",
             "h2 { margin: 0 0 20px 0; font-size: 1.8em; color: #fff; font-weight: 600; }",
@@ -22,64 +23,117 @@
             "input[type=range].move::-webkit-slider-runnable-track { background: #FF2D55; }",
             "input[type=range].exercise::-webkit-slider-runnable-track { background: #A7F070; }",
             "input[type=range].stand::-webkit-slider-runnable-track { background: #00E5E5; }",
+            ".tabulator { max-width: 100%; overflow: auto; }",
+            ".tabulator .tabulator-table { min-width: fit-content; }",
             "@media (max-width: 768px) { #bars { grid-template-columns: 1fr; } }"
         ]
     },
     "dataLoaders": [
         {
-            "dataSourceName": "baseData",
+            "dataSourceName": "activityData",
             "type": "inline",
             "format": "csv",
             "content": [
-                "category,value",
-                "Move,0.7",
-                "Exercise,0.67",
-                "Stand,0.67"
+                "date,move,exercise,stand",
+                "2024-01-01,850,85,18",
+                "2024-01-02,720,95,16",
+                "2024-01-03,950,140,20",
+                "2024-01-04,680,45,14",
+                "2024-01-05,780,110,17",
+                "2024-01-06,890,75,19",
+                "2024-01-07,620,30,13",
+                "2024-01-08,760,125,16",
+                "2024-01-09,840,155,18",
+                "2024-01-10,710,60,15",
+                "2024-01-11,920,180,21",
+                "2024-01-12,650,40,14",
+                "2024-01-13,800,115,17",
+                "2024-01-14,870,135,19",
+                "2024-01-15,590,25,12",
+                "2024-01-16,740,90,16",
+                "2024-01-17,810,165,18",
+                "2024-01-18,690,55,15",
+                "2024-01-19,880,145,20",
+                "2024-01-20,640,35,13",
+                "2024-01-21,770,105,17",
+                "2024-01-22,860,150,19",
+                "2024-01-23,610,50,14",
+                "2024-01-24,750,100,16",
+                "2024-01-25,820,130,18",
+                "2024-01-26,700,65,15",
+                "2024-01-27,890,170,20",
+                "2024-01-28,660,45,14",
+                "2024-01-29,780,120,17",
+                "2024-01-30,850,140,19"
             ]
         }
     ],
     "variables": [
         {
-            "variableId": "move",
-            "type": "number",
-            "initialValue": 150
-        },
-        {
-            "variableId": "exercise",
-            "type": "number",
-            "initialValue": 20
-        },
-        {
-            "variableId": "stand",
-            "type": "number",
-            "initialValue": 8
-        },
-        {
-            "variableId": "selectedDay",
+            "variableId": "selectedDate",
             "type": "string",
-            "initialValue": "Thursday"
+            "initialValue": "2024-01-15"
         },
         {
             "variableId": "moveTarget",
             "type": "number",
-            "initialValue": 210
+            "initialValue": 1000
         },
         {
             "variableId": "exerciseTarget",
             "type": "number",
-            "initialValue": 30
+            "initialValue": 120
         },
         {
             "variableId": "standTarget",
             "type": "number",
-            "initialValue": 12
+            "initialValue": 24
+        },
+        {
+            "variableId": "selectedDayData",
+            "type": "object",
+            "isArray": true,
+            "initialValue": [],
+            "calculation": {
+                "dataSourceNames": ["editableActivityData"],
+                "dataFrameTransformations": [
+                    {
+                        "type": "filter",
+                        "expr": "datum.date === selectedDate"
+                    }
+                ]
+            }
+        },
+        {
+            "variableId": "currentMove",
+            "type": "number",
+            "initialValue": 0,
+            "calculation": {
+                "vegaExpression": "length(data('selectedDayData')) > 0 ? data('selectedDayData')[0].move : 0"
+            }
+        },
+        {
+            "variableId": "currentExercise",
+            "type": "number",
+            "initialValue": 0,
+            "calculation": {
+                "vegaExpression": "length(data('selectedDayData')) > 0 ? data('selectedDayData')[0].exercise : 0"
+            }
+        },
+        {
+            "variableId": "currentStand",
+            "type": "number",
+            "initialValue": 0,
+            "calculation": {
+                "vegaExpression": "length(data('selectedDayData')) > 0 ? data('selectedDayData')[0].stand : 0"
+            }
         },
         {
             "variableId": "moveProgress",
             "type": "number",
             "initialValue": 0,
             "calculation": {
-                "vegaExpression": "min(1, move / moveTarget)"
+                "vegaExpression": "length(data('selectedDayData')) > 0 ? min(1, data('selectedDayData')[0].move / moveTarget) : 0"
             }
         },
         {
@@ -87,7 +141,7 @@
             "type": "number",
             "initialValue": 0,
             "calculation": {
-                "vegaExpression": "min(1, exercise / exerciseTarget)"
+                "vegaExpression": "length(data('selectedDayData')) > 0 ? min(1, data('selectedDayData')[0].exercise / exerciseTarget) : 0"
             }
         },
         {
@@ -95,26 +149,113 @@
             "type": "number",
             "initialValue": 0,
             "calculation": {
-                "vegaExpression": "min(1, stand / standTarget)"
+                "vegaExpression": "length(data('selectedDayData')) > 0 ? min(1, data('selectedDayData')[0].stand / standTarget) : 0"
             }
         },
         {
-            "variableId": "activityData",
+            "variableId": "ringData",
             "type": "object",
             "isArray": true,
             "initialValue": [],
             "calculation": {
-                "dataSourceNames": ["baseData"],
+                "dataSourceNames": ["editableActivityData"],
                 "dataFrameTransformations": [
                     {
                         "type": "formula",
-                        "expr": "datum.category == 'Move' ? moveProgress : datum.category == 'Exercise' ? exerciseProgress : standProgress",
-                        "as": "calculatedValue"
+                        "expr": "selectedDate",
+                        "as": "currentSelected"
+                    },
+                    {
+                        "type": "filter",
+                        "expr": "datum.date === datum.currentSelected"
+                    },
+                    {
+                        "type": "fold",
+                        "fields": ["move", "exercise", "stand"],
+                        "as": ["category", "value"]
                     },
                     {
                         "type": "formula",
-                        "expr": "selectedDay",
+                        "expr": "moveTarget",
+                        "as": "moveTargetValue"
+                    },
+                    {
+                        "type": "formula",
+                        "expr": "exerciseTarget",
+                        "as": "exerciseTargetValue"
+                    },
+                    {
+                        "type": "formula",
+                        "expr": "standTarget",
+                        "as": "standTargetValue"
+                    },
+                    {
+                        "type": "formula",
+                        "expr": "datum.category == 'move' ? min(1, datum.value / datum.moveTargetValue) : datum.category == 'exercise' ? min(1, datum.value / datum.exerciseTargetValue) : min(1, datum.value / datum.standTargetValue)",
+                        "as": "progress"
+                    }
+                ]
+            }
+        },
+        {
+            "variableId": "availableDates",
+            "type": "object",
+            "isArray": true,
+            "initialValue": [],
+            "calculation": {
+                "dataSourceNames": ["editableActivityData"],
+                "dataFrameTransformations": [
+                    {
+                        "type": "aggregate",
+                        "groupby": ["date"],
+                        "ops": ["count"],
+                        "fields": ["date"],
+                        "as": ["count"]
+                    }
+                ]
+            }
+        },
+        {
+            "variableId": "barChartData",
+            "type": "object",
+            "isArray": true,
+            "initialValue": [],
+            "calculation": {
+                "dataSourceNames": ["editableActivityData"],
+                "dataFrameTransformations": [
+                    {
+                        "type": "formula",
+                        "expr": "selectedDate",
+                        "as": "currentSelected"
+                    },
+                    {
+                        "type": "formula",
+                        "expr": "datum.date === datum.currentSelected",
+                        "as": "isSelected"
+                    },
+                    {
+                        "type": "formula",
+                        "expr": "parseInt(split(datum.currentSelected, '-')[2])",
+                        "as": "selectedDay"
+                    },
+                    {
+                        "type": "formula",
+                        "expr": "parseInt(split(datum.date, '-')[2])",
                         "as": "currentDay"
+                    },
+                    {
+                        "type": "formula",
+                        "expr": "datum.selectedDay <= 3 ? 1 : datum.selectedDay >= 28 ? 24 : datum.selectedDay - 3",
+                        "as": "windowStart"
+                    },
+                    {
+                        "type": "formula",
+                        "expr": "datum.selectedDay <= 3 ? 7 : datum.selectedDay >= 28 ? 30 : datum.selectedDay + 3",
+                        "as": "windowEnd"
+                    },
+                    {
+                        "type": "filter",
+                        "expr": "datum.currentDay >= datum.windowStart && datum.currentDay <= datum.windowEnd"
                     }
                 ]
             }
@@ -131,39 +272,15 @@
             "groupId": "controls",
             "elements": [
                 "## Your Daily Progress",
-                "**Day**",
+                "**Date**",
                 {
                     "type": "dropdown",
-                    "variableId": "selectedDay",
-                    "options": ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
-                },
-                "**Move**",
-                {
-                    "type": "slider",
-                    "variableId": "move",
-                    "min": 0,
-                    "max": 315,
-                    "step": 10
-                },
-                "{{move}} / {{moveTarget}} Cal",
-                "**Exercise**",
-                {
-                    "type": "slider",
-                    "variableId": "exercise",
-                    "min": 0,
-                    "max": 45,
-                    "step": 1
-                },
-                "{{exercise}} / {{exerciseTarget}} min",
-                "**Stand**",
-                {
-                    "type": "slider",
-                    "variableId": "stand",
-                    "min": 0,
-                    "max": 18,
-                    "step": 1
-                },
-                "{{stand}} / {{standTarget}} hr"
+                    "variableId": "selectedDate",
+                    "dynamicOptions": {
+                        "dataSourceName": "availableDates",
+                        "fieldName": "date"
+                    }
+                }
             ]
         },
         {
@@ -172,6 +289,62 @@
                 {
                     "type": "chart",
                     "chartKey": "activityRings"
+                }
+            ]
+        },
+        {
+            "groupId": "table",
+            "elements": [
+                "### 📊 Activity Data",
+                "**Edit your daily activity data below**",
+                {
+                    "type": "tabulator",
+                    "variableId": "editableActivityData",
+                    "dataSourceName": "activityData",
+                    "editable": true,
+                    "tabulatorOptions": {
+                        "layout": "fitColumns",
+                        "maxHeight": "300px",
+                        "columns": [
+                            {
+                                "title": "Date",
+                                "field": "date",
+                                "sorter": "date",
+                                "editor": "date"
+                            },
+                            {
+                                "title": "Move (Cal)",
+                                "field": "move",
+                                "editor": "number",
+                                "editorParams": {
+                                    "min": 0,
+                                    "max": 1000,
+                                    "step": 10
+                                }
+                            },
+                            {
+                                "title": "Exercise (min)",
+                                "field": "exercise", 
+                                "editor": "number",
+                                "editorParams": {
+                                    "min": 0,
+                                    "max": 1440,
+                                    "step": 1
+                                }
+                            },
+                            {
+                                "title": "Stand (hr)",
+                                "field": "stand",
+                                "editor": "number",
+                                "editorParams": {
+                                    "min": 0,
+                                    "max": 24,
+                                    "step": 1
+                                }
+                            }
+                        ],
+                        "addRowPos": "top"
+                    }
                 }
             ]
         },
@@ -201,49 +374,60 @@
                 "height": 300,
                 "background": "transparent",
                 "data": {
-                    "name": "activityData"
+                    "name": "selectedDayData"
                 },
+                "transform": [
+                    {
+                        "calculate": "min(1, datum.move / 1000)",
+                        "as": "moveProgress"
+                    },
+                    {
+                        "calculate": "min(1, datum.exercise / 120)",
+                        "as": "exerciseProgress"
+                    },
+                    {
+                        "calculate": "min(1, datum.stand / 24)",
+                        "as": "standProgress"
+                    }
+                ],
                 "layer": [
                     {
-                        "data": {"values": [{"value": 1, "category": "Move"}]},
+                        "data": {"values": [{"value": 1}]},
                         "mark": {"type": "arc", "innerRadius": 100, "outerRadius": 120, "color": "#38383a", "stroke": null},
                         "encoding": {
                             "theta": {"field": "value", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
                         }
                     },
                     {
-                        "data": {"values": [{"value": 1, "category": "Exercise"}]},
+                        "data": {"values": [{"value": 1}]},
                         "mark": {"type": "arc", "innerRadius": 75, "outerRadius": 95, "color": "#38383a", "stroke": null},
                         "encoding": {
                             "theta": {"field": "value", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
                         }
                     },
                     {
-                        "data": {"values": [{"value": 1, "category": "Stand"}]},
+                        "data": {"values": [{"value": 1}]},
                         "mark": {"type": "arc", "innerRadius": 50, "outerRadius": 70, "color": "#38383a", "stroke": null},
                         "encoding": {
                             "theta": {"field": "value", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
                         }
                     },
                     {
-                        "transform": [{"filter": "datum.category == 'Move'"}],
                         "mark": {"type": "arc", "innerRadius": 100, "outerRadius": 120, "cornerRadius": 10, "color": "#FF2D55", "stroke": null},
                         "encoding": {
-                            "theta": {"field": "calculatedValue", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
+                            "theta": {"field": "moveProgress", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
                         }
                     },
                     {
-                        "transform": [{"filter": "datum.category == 'Exercise'"}],
                         "mark": {"type": "arc", "innerRadius": 75, "outerRadius": 95, "cornerRadius": 10, "color": "#A7F070", "stroke": null},
                         "encoding": {
-                            "theta": {"field": "calculatedValue", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
+                            "theta": {"field": "exerciseProgress", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
                         }
                     },
                     {
-                        "transform": [{"filter": "datum.category == 'Stand'"}],
                         "mark": {"type": "arc", "innerRadius": 50, "outerRadius": 70, "cornerRadius": 10, "color": "#00E5E5", "stroke": null},
                         "encoding": {
-                            "theta": {"field": "calculatedValue", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
+                            "theta": {"field": "standProgress", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
                         }
                     }
                 ]
@@ -254,58 +438,15 @@
                 "height": 100,
                 "background": "transparent",
                 "data": {
-                    "name": "activityData"
+                    "name": "barChartData"
                 },
-                "transform": [
-                    {"filter": "datum.category == 'Move'"},
-                    {
-                        "calculate": "'Sunday'",
-                        "as": "day1"
-                    },
-                    {
-                        "calculate": "'Monday'",
-                        "as": "day2"
-                    },
-                    {
-                        "calculate": "'Tuesday'",
-                        "as": "day3"
-                    },
-                    {
-                        "calculate": "'Wednesday'",
-                        "as": "day4"
-                    },
-                    {
-                        "calculate": "'Thursday'",
-                        "as": "day5"
-                    },
-                    {
-                        "calculate": "'Friday'",
-                        "as": "day6"
-                    },
-                    {
-                        "calculate": "'Saturday'",
-                        "as": "day7"
-                    },
-                    {
-                        "fold": ["day1", "day2", "day3", "day4", "day5", "day6", "day7"],
-                        "as": ["dayType", "day"]
-                    },
-                    {
-                        "calculate": "datum.day == datum.currentDay ? datum.calculatedValue : 0.71",
-                        "as": "finalProgress"
-                    },
-                    {
-                        "calculate": "datum.day == datum.currentDay",
-                        "as": "isCurrentDay"
-                    }
-                ],
                 "mark": {"type": "bar", "cornerRadius": 5, "width": {"band": 0.7}},
                 "encoding": {
-                    "y": {"field": "finalProgress", "type": "quantitative", "scale": {"domain": [0, 1.2]}, "axis": null},
-                    "x": {"field": "day", "type": "nominal", "axis": {"title": "Move - Weekly Progress", "labelColor": "#fff", "titleColor": "#fff"}},
+                    "y": {"field": "move", "type": "quantitative", "scale": {"domain": [0, 1000]}, "axis": {"title": "Move (Cal)", "labelColor": "#fff", "titleColor": "#fff"}},
+                    "x": {"field": "date", "type": "temporal", "axis": {"title": "Move - 7 Day Window", "labelColor": "#fff", "titleColor": "#fff"}},
                     "color": {
                         "condition": {
-                            "test": "datum.isCurrentDay",
+                            "test": "datum.isSelected",
                             "value": "#FF2D55"
                         },
                         "value": "#FF2D5580"
@@ -318,58 +459,15 @@
                 "height": 100,
                 "background": "transparent",
                 "data": {
-                    "name": "activityData"
+                    "name": "barChartData"
                 },
-                "transform": [
-                    {"filter": "datum.category == 'Exercise'"},
-                    {
-                        "calculate": "'Sunday'",
-                        "as": "day1"
-                    },
-                    {
-                        "calculate": "'Monday'",
-                        "as": "day2"
-                    },
-                    {
-                        "calculate": "'Tuesday'",
-                        "as": "day3"
-                    },
-                    {
-                        "calculate": "'Wednesday'",
-                        "as": "day4"
-                    },
-                    {
-                        "calculate": "'Thursday'",
-                        "as": "day5"
-                    },
-                    {
-                        "calculate": "'Friday'",
-                        "as": "day6"
-                    },
-                    {
-                        "calculate": "'Saturday'",
-                        "as": "day7"
-                    },
-                    {
-                        "fold": ["day1", "day2", "day3", "day4", "day5", "day6", "day7"],
-                        "as": ["dayType", "day"]
-                    },
-                    {
-                        "calculate": "datum.day == datum.currentDay ? datum.calculatedValue : 0.67",
-                        "as": "finalProgress"
-                    },
-                    {
-                        "calculate": "datum.day == datum.currentDay",
-                        "as": "isCurrentDay"
-                    }
-                ],
                 "mark": {"type": "bar", "cornerRadius": 5, "width": {"band": 0.7}},
                 "encoding": {
-                    "y": {"field": "finalProgress", "type": "quantitative", "scale": {"domain": [0, 1.2]}, "axis": null},
-                    "x": {"field": "day", "type": "nominal", "axis": {"title": "Exercise - Weekly Progress", "labelColor": "#fff", "titleColor": "#fff"}},
+                    "y": {"field": "exercise", "type": "quantitative", "scale": {"domain": [0, 200]}, "axis": {"title": "Exercise (min)", "labelColor": "#fff", "titleColor": "#fff"}},
+                    "x": {"field": "date", "type": "temporal", "axis": {"title": "Exercise - 7 Day Window", "labelColor": "#fff", "titleColor": "#fff"}},
                     "color": {
                         "condition": {
-                            "test": "datum.isCurrentDay",
+                            "test": "datum.isSelected",
                             "value": "#A7F070"
                         },
                         "value": "#A7F07080"
@@ -382,58 +480,15 @@
                 "height": 100,
                 "background": "transparent",
                 "data": {
-                    "name": "activityData"
+                    "name": "barChartData"
                 },
-                "transform": [
-                    {"filter": "datum.category == 'Stand'"},
-                    {
-                        "calculate": "'Sunday'",
-                        "as": "day1"
-                    },
-                    {
-                        "calculate": "'Monday'",
-                        "as": "day2"
-                    },
-                    {
-                        "calculate": "'Tuesday'",
-                        "as": "day3"
-                    },
-                    {
-                        "calculate": "'Wednesday'",
-                        "as": "day4"
-                    },
-                    {
-                        "calculate": "'Thursday'",
-                        "as": "day5"
-                    },
-                    {
-                        "calculate": "'Friday'",
-                        "as": "day6"
-                    },
-                    {
-                        "calculate": "'Saturday'",
-                        "as": "day7"
-                    },
-                    {
-                        "fold": ["day1", "day2", "day3", "day4", "day5", "day6", "day7"],
-                        "as": ["dayType", "day"]
-                    },
-                    {
-                        "calculate": "datum.day == datum.currentDay ? datum.calculatedValue : 0.67",
-                        "as": "finalProgress"
-                    },
-                    {
-                        "calculate": "datum.day == datum.currentDay",
-                        "as": "isCurrentDay"
-                    }
-                ],
                 "mark": {"type": "bar", "cornerRadius": 5, "width": {"band": 0.7}},
                 "encoding": {
-                    "y": {"field": "finalProgress", "type": "quantitative", "scale": {"domain": [0, 1.2]}, "axis": null},
-                    "x": {"field": "day", "type": "nominal", "axis": {"title": "Stand - Weekly Progress", "labelColor": "#fff", "titleColor": "#fff"}},
+                    "y": {"field": "stand", "type": "quantitative", "scale": {"domain": [0, 24]}, "axis": {"title": "Stand (hr)", "labelColor": "#fff", "titleColor": "#fff"}},
+                    "x": {"field": "date", "type": "temporal", "axis": {"title": "Stand - 7 Day Window", "labelColor": "#fff", "titleColor": "#fff"}},
                     "color": {
                         "condition": {
-                            "test": "datum.isCurrentDay",
+                            "test": "datum.isSelected",
                             "value": "#00E5E5"
                         },
                         "value": "#00E5E580"

--- a/packages/web-deploy/json/activity-rings.idoc.json
+++ b/packages/web-deploy/json/activity-rings.idoc.json
@@ -1,6 +1,6 @@
 {
     "$schema": "../../../docs/schema/idoc_v1.json",
-    "title": "Apple Fitness Rings",
+    "title": "Fitness Rings",
     "style": {
         "css": [
             "body { font-family: 'SF Pro Display', 'Helvetica Neue', 'Arial', sans-serif; margin: 0; padding: 20px; background: #000; color: #fff; }",

--- a/packages/web-deploy/json/activity-rings.idoc.json
+++ b/packages/web-deploy/json/activity-rings.idoc.json
@@ -1,0 +1,445 @@
+{
+    "$schema": "../../../docs/schema/idoc_v1.json",
+    "title": "Apple Fitness Rings",
+    "style": {
+        "css": [
+            "body { font-family: 'SF Pro Display', 'Helvetica Neue', 'Arial', sans-serif; margin: 0; padding: 20px; background: #000; color: #fff; }",
+            "body { display: grid; grid-template-areas: 'header' 'controls' 'rings' 'bars'; grid-template-columns: 1fr; gap: 30px; max-width: 800px; margin: 0 auto; }",
+            ".group { background: #1c1c1e; padding: 25px; border-radius: 20px; border: 1px solid #38383a; }",
+            "#header { grid-area: header; text-align: center; background: none; border: none; padding: 0; }",
+            "#controls { grid-area: controls; }",
+            "#rings { grid-area: rings; min-width: 0; display: flex; justify-content: center; align-items: center; }",
+            "#bars { grid-area: bars; min-width: 0; display: grid; grid-template-columns: 1fr; gap: 20px; }",
+            "h1 { margin: 0 0 30px 0; font-size: 2.5em; font-weight: 700; }",
+            "h2 { margin: 0 0 20px 0; font-size: 1.8em; color: #fff; font-weight: 600; }",
+            "h3 { margin: 0 0 15px 0; font-size: 1.1em; color: #8e8e93; font-weight: 500; text-transform: uppercase; letter-spacing: 0.8px; }",
+            ".slider-container { display: grid; grid-template-columns: 100px 1fr 60px; align-items: center; gap: 15px; margin-bottom: 15px; }",
+            ".slider-container label { font-weight: 600; font-size: 1.1em; }",
+            ".slider-container span { font-size: 1.1em; text-align: right; color: #8e8e93; }",
+            "input[type=range] { -webkit-appearance: none; background: transparent; width: 100%; }",
+            "input[type=range]::-webkit-slider-runnable-track { height: 8px; border-radius: 4px; background: #38383a; }",
+            "input[type=range]::-webkit-slider-thumb { -webkit-appearance: none; margin-top: -6px; width: 20px; height: 20px; border-radius: 50%; background: #fff; cursor: pointer; }",
+            "input[type=range].move::-webkit-slider-runnable-track { background: #FF2D55; }",
+            "input[type=range].exercise::-webkit-slider-runnable-track { background: #A7F070; }",
+            "input[type=range].stand::-webkit-slider-runnable-track { background: #00E5E5; }",
+            "@media (max-width: 768px) { #bars { grid-template-columns: 1fr; } }"
+        ]
+    },
+    "dataLoaders": [
+        {
+            "dataSourceName": "baseData",
+            "type": "inline",
+            "format": "csv",
+            "content": [
+                "category,value",
+                "Move,0.7",
+                "Exercise,0.67",
+                "Stand,0.67"
+            ]
+        }
+    ],
+    "variables": [
+        {
+            "variableId": "move",
+            "type": "number",
+            "initialValue": 150
+        },
+        {
+            "variableId": "exercise",
+            "type": "number",
+            "initialValue": 20
+        },
+        {
+            "variableId": "stand",
+            "type": "number",
+            "initialValue": 8
+        },
+        {
+            "variableId": "selectedDay",
+            "type": "string",
+            "initialValue": "Thursday"
+        },
+        {
+            "variableId": "moveTarget",
+            "type": "number",
+            "initialValue": 210
+        },
+        {
+            "variableId": "exerciseTarget",
+            "type": "number",
+            "initialValue": 30
+        },
+        {
+            "variableId": "standTarget",
+            "type": "number",
+            "initialValue": 12
+        },
+        {
+            "variableId": "moveProgress",
+            "type": "number",
+            "initialValue": 0,
+            "calculation": {
+                "vegaExpression": "min(1, move / moveTarget)"
+            }
+        },
+        {
+            "variableId": "exerciseProgress",
+            "type": "number",
+            "initialValue": 0,
+            "calculation": {
+                "vegaExpression": "min(1, exercise / exerciseTarget)"
+            }
+        },
+        {
+            "variableId": "standProgress",
+            "type": "number",
+            "initialValue": 0,
+            "calculation": {
+                "vegaExpression": "min(1, stand / standTarget)"
+            }
+        },
+        {
+            "variableId": "activityData",
+            "type": "object",
+            "isArray": true,
+            "initialValue": [],
+            "calculation": {
+                "dataSourceNames": ["baseData"],
+                "dataFrameTransformations": [
+                    {
+                        "type": "formula",
+                        "expr": "datum.category == 'Move' ? moveProgress : datum.category == 'Exercise' ? exerciseProgress : standProgress",
+                        "as": "calculatedValue"
+                    },
+                    {
+                        "type": "formula",
+                        "expr": "selectedDay",
+                        "as": "currentDay"
+                    }
+                ]
+            }
+        }
+    ],
+    "groups": [
+        {
+            "groupId": "header",
+            "elements": [
+                "# Fitness Rings"
+            ]
+        },
+        {
+            "groupId": "controls",
+            "elements": [
+                "## Your Daily Progress",
+                "**Day**",
+                {
+                    "type": "dropdown",
+                    "variableId": "selectedDay",
+                    "options": ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+                },
+                "**Move**",
+                {
+                    "type": "slider",
+                    "variableId": "move",
+                    "min": 0,
+                    "max": 315,
+                    "step": 10
+                },
+                "{{move}} / {{moveTarget}} Cal",
+                "**Exercise**",
+                {
+                    "type": "slider",
+                    "variableId": "exercise",
+                    "min": 0,
+                    "max": 45,
+                    "step": 1
+                },
+                "{{exercise}} / {{exerciseTarget}} min",
+                "**Stand**",
+                {
+                    "type": "slider",
+                    "variableId": "stand",
+                    "min": 0,
+                    "max": 18,
+                    "step": 1
+                },
+                "{{stand}} / {{standTarget}} hr"
+            ]
+        },
+        {
+            "groupId": "rings",
+            "elements": [
+                {
+                    "type": "chart",
+                    "chartKey": "activityRings"
+                }
+            ]
+        },
+        {
+            "groupId": "bars",
+            "elements": [
+                {
+                    "type": "chart",
+                    "chartKey": "moveBar"
+                },
+                {
+                    "type": "chart",
+                    "chartKey": "exerciseBar"
+                },
+                {
+                    "type": "chart",
+                    "chartKey": "standBar"
+                }
+            ]
+        }
+    ],
+    "resources": {
+        "charts": {
+            "activityRings": {
+                "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
+                "width": 300,
+                "height": 300,
+                "background": "transparent",
+                "data": {
+                    "name": "activityData"
+                },
+                "layer": [
+                    {
+                        "data": {"values": [{"value": 1, "category": "Move"}]},
+                        "mark": {"type": "arc", "innerRadius": 100, "outerRadius": 120, "color": "#38383a", "stroke": null},
+                        "encoding": {
+                            "theta": {"field": "value", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
+                        }
+                    },
+                    {
+                        "data": {"values": [{"value": 1, "category": "Exercise"}]},
+                        "mark": {"type": "arc", "innerRadius": 75, "outerRadius": 95, "color": "#38383a", "stroke": null},
+                        "encoding": {
+                            "theta": {"field": "value", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
+                        }
+                    },
+                    {
+                        "data": {"values": [{"value": 1, "category": "Stand"}]},
+                        "mark": {"type": "arc", "innerRadius": 50, "outerRadius": 70, "color": "#38383a", "stroke": null},
+                        "encoding": {
+                            "theta": {"field": "value", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
+                        }
+                    },
+                    {
+                        "transform": [{"filter": "datum.category == 'Move'"}],
+                        "mark": {"type": "arc", "innerRadius": 100, "outerRadius": 120, "cornerRadius": 10, "color": "#FF2D55", "stroke": null},
+                        "encoding": {
+                            "theta": {"field": "calculatedValue", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
+                        }
+                    },
+                    {
+                        "transform": [{"filter": "datum.category == 'Exercise'"}],
+                        "mark": {"type": "arc", "innerRadius": 75, "outerRadius": 95, "cornerRadius": 10, "color": "#A7F070", "stroke": null},
+                        "encoding": {
+                            "theta": {"field": "calculatedValue", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
+                        }
+                    },
+                    {
+                        "transform": [{"filter": "datum.category == 'Stand'"}],
+                        "mark": {"type": "arc", "innerRadius": 50, "outerRadius": 70, "cornerRadius": 10, "color": "#00E5E5", "stroke": null},
+                        "encoding": {
+                            "theta": {"field": "calculatedValue", "type": "quantitative", "scale": {"domain": [0, 1], "range": [0, 6.283]}}
+                        }
+                    }
+                ]
+            },
+            "moveBar": {
+                "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
+                "width": "container",
+                "height": 100,
+                "background": "transparent",
+                "data": {
+                    "name": "activityData"
+                },
+                "transform": [
+                    {"filter": "datum.category == 'Move'"},
+                    {
+                        "calculate": "'Sunday'",
+                        "as": "day1"
+                    },
+                    {
+                        "calculate": "'Monday'",
+                        "as": "day2"
+                    },
+                    {
+                        "calculate": "'Tuesday'",
+                        "as": "day3"
+                    },
+                    {
+                        "calculate": "'Wednesday'",
+                        "as": "day4"
+                    },
+                    {
+                        "calculate": "'Thursday'",
+                        "as": "day5"
+                    },
+                    {
+                        "calculate": "'Friday'",
+                        "as": "day6"
+                    },
+                    {
+                        "calculate": "'Saturday'",
+                        "as": "day7"
+                    },
+                    {
+                        "fold": ["day1", "day2", "day3", "day4", "day5", "day6", "day7"],
+                        "as": ["dayType", "day"]
+                    },
+                    {
+                        "calculate": "datum.day == datum.currentDay ? datum.calculatedValue : 0.71",
+                        "as": "finalProgress"
+                    },
+                    {
+                        "calculate": "datum.day == datum.currentDay",
+                        "as": "isCurrentDay"
+                    }
+                ],
+                "mark": {"type": "bar", "cornerRadius": 5, "width": {"band": 0.7}},
+                "encoding": {
+                    "y": {"field": "finalProgress", "type": "quantitative", "scale": {"domain": [0, 1.2]}, "axis": null},
+                    "x": {"field": "day", "type": "nominal", "axis": {"title": "Move - Weekly Progress", "labelColor": "#fff", "titleColor": "#fff"}},
+                    "color": {
+                        "condition": {
+                            "test": "datum.isCurrentDay",
+                            "value": "#FF2D55"
+                        },
+                        "value": "#FF2D5580"
+                    }
+                }
+            },
+            "exerciseBar": {
+                "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
+                "width": "container",
+                "height": 100,
+                "background": "transparent",
+                "data": {
+                    "name": "activityData"
+                },
+                "transform": [
+                    {"filter": "datum.category == 'Exercise'"},
+                    {
+                        "calculate": "'Sunday'",
+                        "as": "day1"
+                    },
+                    {
+                        "calculate": "'Monday'",
+                        "as": "day2"
+                    },
+                    {
+                        "calculate": "'Tuesday'",
+                        "as": "day3"
+                    },
+                    {
+                        "calculate": "'Wednesday'",
+                        "as": "day4"
+                    },
+                    {
+                        "calculate": "'Thursday'",
+                        "as": "day5"
+                    },
+                    {
+                        "calculate": "'Friday'",
+                        "as": "day6"
+                    },
+                    {
+                        "calculate": "'Saturday'",
+                        "as": "day7"
+                    },
+                    {
+                        "fold": ["day1", "day2", "day3", "day4", "day5", "day6", "day7"],
+                        "as": ["dayType", "day"]
+                    },
+                    {
+                        "calculate": "datum.day == datum.currentDay ? datum.calculatedValue : 0.67",
+                        "as": "finalProgress"
+                    },
+                    {
+                        "calculate": "datum.day == datum.currentDay",
+                        "as": "isCurrentDay"
+                    }
+                ],
+                "mark": {"type": "bar", "cornerRadius": 5, "width": {"band": 0.7}},
+                "encoding": {
+                    "y": {"field": "finalProgress", "type": "quantitative", "scale": {"domain": [0, 1.2]}, "axis": null},
+                    "x": {"field": "day", "type": "nominal", "axis": {"title": "Exercise - Weekly Progress", "labelColor": "#fff", "titleColor": "#fff"}},
+                    "color": {
+                        "condition": {
+                            "test": "datum.isCurrentDay",
+                            "value": "#A7F070"
+                        },
+                        "value": "#A7F07080"
+                    }
+                }
+            },
+            "standBar": {
+                "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
+                "width": "container",
+                "height": 100,
+                "background": "transparent",
+                "data": {
+                    "name": "activityData"
+                },
+                "transform": [
+                    {"filter": "datum.category == 'Stand'"},
+                    {
+                        "calculate": "'Sunday'",
+                        "as": "day1"
+                    },
+                    {
+                        "calculate": "'Monday'",
+                        "as": "day2"
+                    },
+                    {
+                        "calculate": "'Tuesday'",
+                        "as": "day3"
+                    },
+                    {
+                        "calculate": "'Wednesday'",
+                        "as": "day4"
+                    },
+                    {
+                        "calculate": "'Thursday'",
+                        "as": "day5"
+                    },
+                    {
+                        "calculate": "'Friday'",
+                        "as": "day6"
+                    },
+                    {
+                        "calculate": "'Saturday'",
+                        "as": "day7"
+                    },
+                    {
+                        "fold": ["day1", "day2", "day3", "day4", "day5", "day6", "day7"],
+                        "as": ["dayType", "day"]
+                    },
+                    {
+                        "calculate": "datum.day == datum.currentDay ? datum.calculatedValue : 0.67",
+                        "as": "finalProgress"
+                    },
+                    {
+                        "calculate": "datum.day == datum.currentDay",
+                        "as": "isCurrentDay"
+                    }
+                ],
+                "mark": {"type": "bar", "cornerRadius": 5, "width": {"band": 0.7}},
+                "encoding": {
+                    "y": {"field": "finalProgress", "type": "quantitative", "scale": {"domain": [0, 1.2]}, "axis": null},
+                    "x": {"field": "day", "type": "nominal", "axis": {"title": "Stand - Weekly Progress", "labelColor": "#fff", "titleColor": "#fff"}},
+                    "color": {
+                        "condition": {
+                            "test": "datum.isCurrentDay",
+                            "value": "#00E5E5"
+                        },
+                        "value": "#00E5E580"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is to add a Fitness Rings example where users can navigate through the dates and get their biometrics information for Move, Exercise and Stand. Also it will show bar charts with the specific date in a 7-day window logic.

Preview
https://microsoft.github.io/chartifact/view/?load=https://raw.githubusercontent.com/reyesrico/chartifact/refs/heads/fitness/packages/web-deploy/json/activity-rings.idoc.json

<img width="407" height="1093" alt="Screenshot 2025-09-17 at 11 10 19 AM" src="https://github.com/user-attachments/assets/f6706a0c-f380-405e-a21b-1041ad2c6d6a" />

<img width="406" height="995" alt="Screenshot 2025-09-17 at 11 10 27 AM" src="https://github.com/user-attachments/assets/78c3e29c-e5db-4fa0-9e6a-bbe6027ef360" />
